### PR TITLE
Add Disk Cache Attribute

### DIFF
--- a/src/main/java/lcmc/data/VMSXML.java
+++ b/src/main/java/lcmc/data/VMSXML.java
@@ -303,6 +303,8 @@ public final class VMSXML extends XML {
         DISK_ATTRIBUTE_MAP.put(DiskData.DRIVER_NAME, "name");
         DISK_TAG_MAP.put(DiskData.DRIVER_TYPE, "driver");
         DISK_ATTRIBUTE_MAP.put(DiskData.DRIVER_TYPE, "type");
+        DISK_TAG_MAP.put(DiskData.DRIVER_CACHE, "driver");
+        DISK_ATTRIBUTE_MAP.put(DiskData.DRIVER_CACHE, "cache");
         DISK_ATTRIBUTE_MAP.put(DiskData.TARGET_TYPE, "device");
         DISK_TAG_MAP.put(DiskData.READONLY, "readonly");
         DISK_TAG_MAP.put(DiskData.SHAREABLE, "shareable");
@@ -1557,6 +1559,7 @@ public final class VMSXML extends XML {
                         String targetBus = null;
                         String driverName = null;
                         String driverType = null;
+                        String driverCache = null;
                         boolean readonly = false;
                         boolean shareable = false;
                         for (int k = 0; k < opts.getLength(); k++) {
@@ -1576,6 +1579,7 @@ public final class VMSXML extends XML {
                             } else if ("driver".equals(nodeName)) {
                                 driverName = getAttribute(optionNode, "name");
                                 driverType = getAttribute(optionNode, "type");
+                                driverCache = getAttribute(optionNode, "cache");
                             } else if ("readonly".equals(nodeName)) {
                                 readonly = true;
                             } else if ("shareable".equals(nodeName)) {
@@ -1596,6 +1600,7 @@ public final class VMSXML extends XML {
                                                       targetBus + "/" + device,
                                                       driverName,
                                                       driverType,
+                                                      driverCache,
                                                       readonly,
                                                       shareable);
                             devMap.put(targetDev, diskData);
@@ -2343,6 +2348,8 @@ public final class VMSXML extends XML {
         private final String driverName;
         /** Driver type: raw... */
         private final String driverType;
+        /** Driver cache: none... */
+        private final String driverCache;
         /** Whether the disk is read only. */
         private final boolean readonly;
         /** Whether the disk is shareable. */
@@ -2367,6 +2374,8 @@ public final class VMSXML extends XML {
         public static final String DRIVER_NAME = "driver_name";
         /** Driver type. */
         public static final String DRIVER_TYPE = "driver_type";
+        /** Driver cache. */
+        public static final String DRIVER_CACHE = "driver_cache";
         /** Readonly. */
         public static final String READONLY = "readonly";
         /** Shareable. */
@@ -2380,6 +2389,7 @@ public final class VMSXML extends XML {
                         final String targetBusType,
                         final String driverName,
                         final String driverType,
+                        final String driverCache,
                         final boolean readonly,
                         final boolean shareable) {
             super();
@@ -2397,6 +2407,8 @@ public final class VMSXML extends XML {
             setValue(DRIVER_NAME, driverName);
             this.driverType = driverType;
             setValue(DRIVER_TYPE, driverType);
+            this.driverCache = driverCache;
+            setValue(DRIVER_CACHE, driverCache);
             this.readonly = readonly;
             if (readonly) {
                 setValue(READONLY, "True");
@@ -2444,6 +2456,11 @@ public final class VMSXML extends XML {
         /** Returns driver type. */
         String getDriverType() {
             return driverType;
+        }
+
+        /** Returns driver cache. */
+        String getDriverCache() {
+            return driverCache;
         }
 
         /** Returns whether the disk is read only. */

--- a/src/main/java/lcmc/gui/dialog/vm/InstallationDisk.java
+++ b/src/main/java/lcmc/gui/dialog/vm/InstallationDisk.java
@@ -55,6 +55,7 @@ final class InstallationDisk extends VMConfig {
                                             DiskData.SOURCE_DEVICE,
                                             DiskData.DRIVER_NAME,
                                             DiskData.DRIVER_TYPE,
+                                            DiskData.DRIVER_CACHE,
                                             DiskData.READONLY};
     /** VMS disk info object. */
     private VMSDiskInfo vmsdi = null;
@@ -141,6 +142,7 @@ final class InstallationDisk extends VMConfig {
         vmsdi.getResource().setValue(DiskData.TARGET_BUS_TYPE, "IDE CDROM");
         vmsdi.getResource().setValue(DiskData.TARGET_DEVICE, "hdc");
         vmsdi.getResource().setValue(DiskData.DRIVER_TYPE, "raw");
+        vmsdi.getResource().setValue(DiskData.DRIVER_CACHE, "default");
         vmsdi.getResource().setValue(DiskData.READONLY, "True");
         vmsdi.getResource().setValue(DiskData.SOURCE_FILE,
                                      VMSDiskInfo.LIBVIRT_IMAGE_LOCATION);

--- a/src/main/java/lcmc/gui/resources/VMSDiskInfo.java
+++ b/src/main/java/lcmc/gui/resources/VMSDiskInfo.java
@@ -68,6 +68,9 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
     /** Driver type combo box. */
     private final Map<String, Widget> driverTypeWi =
                                             new HashMap<String, Widget>();
+    /** Driver cache combo box. */
+    private final Map<String, Widget> driverCacheWi =
+                                            new HashMap<String, Widget>();
     /** Readonly combo box. */
     private final Map<String, Widget> readonlyWi =
                                             new HashMap<String, Widget>();
@@ -81,6 +84,7 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
                                                 DiskData.SOURCE_DEVICE,
                                                 DiskData.DRIVER_NAME,
                                                 DiskData.DRIVER_TYPE,
+                                                DiskData.DRIVER_CACHE,
                                                 DiskData.READONLY,
                                                 DiskData.SHAREABLE};
     /** Block parameters. */
@@ -90,6 +94,7 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
                                                       DiskData.SOURCE_DEVICE,
                                                       DiskData.DRIVER_NAME,
                                                       DiskData.DRIVER_TYPE,
+                                                      DiskData.DRIVER_CACHE,
                                                       DiskData.READONLY,
                                                       DiskData.SHAREABLE};
     /** File parameters. */
@@ -99,6 +104,7 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
                                                      DiskData.TARGET_BUS_TYPE,
                                                      DiskData.DRIVER_NAME,
                                                      DiskData.DRIVER_TYPE,
+                                                     DiskData.DRIVER_CACHE,
                                                      DiskData.READONLY,
                                                      DiskData.SHAREABLE};
     /** Whether the parameter is enabled only in advanced mode. */
@@ -106,7 +112,8 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
         new HashSet<String>(Arrays.asList(new String[]{
                                                 DiskData.TARGET_DEVICE,
                                                 DiskData.DRIVER_NAME,
-                                                DiskData.DRIVER_TYPE}));
+                                                DiskData.DRIVER_TYPE,
+                                                DiskData.DRIVER_CACHE}));
     /** Whether the parameter is required. */
     private static final Set<String> IS_REQUIRED =
         new HashSet<String>(Arrays.asList(new String[]{DiskData.TYPE}));
@@ -134,6 +141,7 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
         SHORTNAME_MAP.put(DiskData.TARGET_BUS_TYPE, "Disk Type");
         SHORTNAME_MAP.put(DiskData.DRIVER_NAME, "Driver Name");
         SHORTNAME_MAP.put(DiskData.DRIVER_TYPE, "Driver Type");
+        SHORTNAME_MAP.put(DiskData.DRIVER_CACHE, "Driver Cache");
         SHORTNAME_MAP.put(DiskData.READONLY, "Readonly");
         SHORTNAME_MAP.put(DiskData.SHAREABLE, "Shareable");
     }
@@ -185,6 +193,7 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
                                                           DRIVER_NAME_QEMU,
                                                           DRIVER_NAME_PHY});
         POSSIBLE_VALUES.put(DiskData.DRIVER_TYPE, new String[]{null, "raw"});
+        POSSIBLE_VALUES.put(DiskData.DRIVER_CACHE, new String[]{null, "default", "none", "writethrough", "writeback", "directsync", "unsafe"});
         for (final StringInfo tbt : (StringInfo[]) POSSIBLE_VALUES.get(
                                                   DiskData.TARGET_BUS_TYPE)) {
             TARGET_BUS_TYPES.put(tbt.getStringValue(), tbt.toString());
@@ -591,6 +600,9 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
                     for (final String p : driverTypeWi.keySet()) {
                         driverTypeWi.get(p).setValue("raw");
                     }
+                    for (final String p : driverCacheWi.keySet()) {
+                        driverCacheWi.get(p).setValue("none");
+                    }
                 } else {
                     for (final String p : readonlyWi.keySet()) {
                         readonlyWi.get(p).setValue("False");
@@ -747,6 +759,12 @@ public final class VMSDiskInfo extends VMSHardwareInfo {
                     driverTypeWi.put("", paramWi);
                 } else {
                     driverTypeWi.put(prefix, paramWi);
+                }
+            } else if (DiskData.DRIVER_CACHE.equals(param)) {
+                if (prefix == null) {
+                    driverCacheWi.put("", paramWi);
+                } else {
+                    driverCacheWi.put(prefix, paramWi);
                 }
             } else if (DiskData.READONLY.equals(param)) {
                 if (prefix == null) {


### PR DESCRIPTION
Hello,

Just added the disk cache attribute to the VMs definition and VM creation dialog boxes. 
Now permit to live migrate VMs from an host to another when disk cache is set to "none" 
Please see http://publib.boulder.ibm.com/infocenter/lnxinfo/v3r0m0/index.jsp?topic=%2Fliaat%2Fliaattunkickoff.htm for more informations. 

Best regards
