### PR TITLE
Add build script and icon for creating OSX packages

### DIFF
--- a/osx/build.sh
+++ b/osx/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Requirements:
+# - Platypus `brew install platypus` http://www.sveinbjorn.org/platypus
+# - LCMC-1.7.8.jar in current working directory
+
+/usr/local/bin/platypus -R  -i '../scripts/lcmc-logo-icon.icns' -a 'LCMC'  -o 'None' -p '/usr/bin/java' -I org.java.LCMC -G '-jar' 'LCMC-1.7.8.jar'

--- a/scripts/lcmc-logo-icon.icns
+++ b/scripts/lcmc-logo-icon.icns
@@ -1,0 +1,22 @@
+How to use this icon:
+
+Step 1: Copy the icon to the clipboard
+a) Click on this file from the Finder
+b) Choose 'Get Info' from the 'File' menu.
+c) In the info window that pops up, click on the icon
+d) Choose 'Copy' from the 'Edit' menu.
+e) Close the info window
+
+Step 2: Paste the icon to the desired item
+a) Go to the item in the Finder that you want a custom icon
+b) Click the item (file, folder, disk, etc) 
+b) Choose 'Get Info' from the 'File' menu.
+c) In the info window that pops up, click on the icon
+d) Choose 'Paste' from the 'Edit' menu.
+e) Close the info window
+
+Step 3: 
+Enjoy your newly customized icon!
+
+For more thorough directions, see Apple's website at:
+http://www.apple.com/support/mac101/customize/6/


### PR DESCRIPTION
Running build.sh will generate an OSX .app bundle that can be run on any Mac with Java installed.

- Requires [platypus](http://www.sveinbjorn.org/platypus) which can be installed via homebrew: `brew install platypus`
- Added .icns format icon.