### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used. 

### DIFF
--- a/src/main/java/lcmc/cluster/service/ssh/ExecCommandThread.java
+++ b/src/main/java/lcmc/cluster/service/ssh/ExecCommandThread.java
@@ -356,7 +356,7 @@ public final class ExecCommandThread extends Thread {
                     enterSudoPassword();
                 }
                 final String pwd = host.getSudoPassword() + '\n';
-                stdin.write(pwd.getBytes());
+                stdin.write(pwd.getBytes("UTF-8"));
                 skipNextLine = true;
                 continue;
             } else if (output.indexOf(Ssh.SUDO_FAIL) >= 0) {

--- a/src/main/java/lcmc/cluster/service/ssh/Ssh.java
+++ b/src/main/java/lcmc/cluster/service/ssh/Ssh.java
@@ -374,7 +374,7 @@ public class Ssh {
         final String fileName = "lcmc-test.tar";
         final String file = Tools.getFile('/' + fileName);
         try {
-            scpClient.put(file.getBytes(), fileName, "/tmp");
+            scpClient.put(file.getBytes("UTF-8"), fileName, "/tmp");
         } catch (final IOException e) {
             LOG.appError("installTestFiles: could not copy: " + fileName, "", e);
             return;

--- a/src/main/java/lcmc/common/domain/Http.java
+++ b/src/main/java/lcmc/common/domain/Http.java
@@ -104,7 +104,7 @@ public final class Http {
 
         /* Response */
         try {
-            final BufferedReader input = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            final BufferedReader input = new BufferedReader(new InputStreamReader(conn.getInputStream(), ENCODING));
             String str;
             while (null != ((str = input.readLine()))) {
                 LOG.info("post: " + str);

--- a/src/main/java/lcmc/common/domain/XMLTools.java
+++ b/src/main/java/lcmc/common/domain/XMLTools.java
@@ -94,7 +94,7 @@ public class XMLTools {
         final Document document;
         try {
             final DocumentBuilder builder = factory.newDocumentBuilder();
-            document = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+            document = builder.parse(new ByteArrayInputStream(xml.getBytes("UTF-8")));
         } catch (final SAXException sxe) {
             LOG.appError("getXMLDocument: could not parse: " + xml, sxe);
             return null;

--- a/src/main/java/lcmc/common/domain/util/Tools.java
+++ b/src/main/java/lcmc/common/domain/util/Tools.java
@@ -33,6 +33,7 @@ import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -79,6 +80,7 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.text.html.HTMLDocument;
 
 import com.google.common.base.Optional;
+
 import lcmc.Exceptions;
 import lcmc.common.domain.ConvertCmdCallback;
 import lcmc.common.domain.StringValue;
@@ -229,7 +231,7 @@ public final class Tools {
         final BufferedReader in;
         final StringBuilder content = new StringBuilder("");
         try {
-            in = new BufferedReader(new FileReader(filename));
+            in = new BufferedReader(new InputStreamReader(new FileInputStream(new File(filename)), "UTF-8"));
             String line;
             while ((line = in.readLine()) != null) {
                 content.append(line);
@@ -794,7 +796,7 @@ public final class Tools {
             return null;
         }
         try {
-            final BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream()));
+            final BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
             final StringBuilder content = new StringBuilder("");
             while (br.ready()) {
                 content.append(br.readLine());
@@ -830,7 +832,7 @@ public final class Tools {
         String info = null;
         try {
             final String url = "http://lcmc.sourceforge.net/version.html?lcmc-check-" + getRelease();
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(url).openStream()));
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(url).openStream(), "UTF-8"));
             int rate = 0;
             do {
                 final String line = reader.readLine();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed