### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/src/main/java/lcmc/cluster/ui/ClustersPanel.java
+++ b/src/main/java/lcmc/cluster/ui/ClustersPanel.java
@@ -94,7 +94,7 @@ public final class ClustersPanel extends JPanel {
                 previouslySelectedTab = (ClusterTab) prevSource.getSelectedComponent();
 
                 /* show dialogs only if got here from other tab. */
-                if ((source == null || source.getName() == null)) {
+                if (source == null || source.getName() == null) {
                     return;
                 }
 

--- a/src/main/java/lcmc/cluster/ui/wizard/ClusterHosts.java
+++ b/src/main/java/lcmc/cluster/ui/wizard/ClusterHosts.java
@@ -267,7 +267,7 @@ final class ClusterHosts extends DialogCluster {
         public int getScrollableUnitIncrement(final Rectangle visibleRect, final int orientation, final int direction) {
             final int hundredth = (orientation ==  SwingConstants.VERTICAL
                     ? getParent().getHeight() : getParent().getWidth()) / 100;
-            return (hundredth == 0 ? 1 : hundredth);
+            return hundredth == 0 ? 1 : hundredth;
         }
 
         @Override

--- a/src/main/java/lcmc/cluster/ui/wizard/InitCluster.java
+++ b/src/main/java/lcmc/cluster/ui/wizard/InitCluster.java
@@ -247,18 +247,18 @@ public class InitCluster extends DialogCluster {
 
         /* DRBD */
         i = 0;
-        final boolean lastDrbdLoadedExists = (lastDrbdLoaded != null);
+        final boolean lastDrbdLoadedExists = lastDrbdLoaded != null;
         if (!lastDrbdLoadedExists) {
             lastDrbdLoaded = new Boolean[hosts.length];
         }
-        final boolean lastPmStartedExists = (lastPacemakerStarted != null);
+        final boolean lastPmStartedExists = lastPacemakerStarted != null;
         if (!lastPmStartedExists) {
             lastPacemakerStarted = new Boolean[hosts.length];
             lastPacemakerInRc = new Boolean[hosts.length];
             lastPacemakerConfigured = new Boolean[hosts.length];
             lastPacemakerInstalled = new Boolean[hosts.length];
         }
-        final boolean lastHbStartedExists = (lastHeartbeatStarted != null);
+        final boolean lastHbStartedExists = lastHeartbeatStarted != null;
         if (!lastHbStartedExists) {
             lastHeartbeatStarted = new Boolean[hosts.length];
             lastHeartbeatInRc = new Boolean[hosts.length];

--- a/src/main/java/lcmc/common/domain/Http.java
+++ b/src/main/java/lcmc/common/domain/Http.java
@@ -106,7 +106,7 @@ public final class Http {
         try {
             final BufferedReader input = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String str;
-            while (null != ((str = input.readLine()))) {
+            while (null != (str = input.readLine())) {
                 LOG.info("post: " + str);
             }
             input.close();

--- a/src/main/java/lcmc/drbd/ui/resource/VolumeInfo.java
+++ b/src/main/java/lcmc/drbd/ui/resource/VolumeInfo.java
@@ -160,8 +160,8 @@ public class VolumeInfo extends EditableInfo implements CommonDeviceInterface {
               final List<BlockDevInfo> blockDevInfos,
               final Browser browser) {
         super.einit(Optional.<ResourceValue>of(new DrbdVolume(name)), name, browser);
-        assert (resourceInfo != null);
-        assert (blockDevInfos.size() >= 2);
+        assert resourceInfo != null;
+        assert blockDevInfos.size() >= 2;
 
         this.resourceInfo = resourceInfo;
         this.blockDevInfos = Collections.unmodifiableList(blockDevInfos);

--- a/src/main/java/lcmc/host/ui/NewHostDialog.java
+++ b/src/main/java/lcmc/host/ui/NewHostDialog.java
@@ -107,9 +107,9 @@ public class NewHostDialog extends DialogHost {
         final String hs = hostField.getStringValue().trim();
         final String us = usernameField.getStringValue().trim();
         final String ps = sshPortField.getStringValue().trim();
-        boolean hf = (!hs.isEmpty());
-        boolean uf = (!us.isEmpty());
-        final boolean pf = (!ps.isEmpty());
+        boolean hf = !hs.isEmpty();
+        boolean uf = !us.isEmpty();
+        final boolean pf = !ps.isEmpty();
         final int hc = Tools.charCount(hs, ',');
         final int uc = Tools.charCount(us, ',');
         final List<String> incorrect = new ArrayList<String>();

--- a/src/main/java/lcmc/vm/ui/resource/DomainInfo.java
+++ b/src/main/java/lcmc/vm/ui/resource/DomainInfo.java
@@ -1568,7 +1568,7 @@ public class DomainInfo extends EditableInfo {
             final Widget hwi = definedOnHostComboBoxHash.get(h.getName());
             if (hwi != null) {
                 final Value value;
-                if ((vmsXml != null && vmsXml.getDomainNames().contains(getDomainName()))) {
+                if (vmsXml != null && vmsXml.getDomainNames().contains(getDomainName())) {
                     value = DEFINED_ON_HOST_TRUE;
                 } else {
                     value = DEFINED_ON_HOST_FALSE;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed