### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness.

### DIFF
--- a/src/main/java/lcmc/ArgumentParser.java
+++ b/src/main/java/lcmc/ArgumentParser.java
@@ -396,7 +396,7 @@ public class ArgumentParser {
         }
         for (final Map.Entry<String, List<HostOptions>> clusterEntry : clusters.entrySet()) {
             final List<HostOptions> hostOptions = clusterEntry.getValue();
-            if (hostOptions.size() < 1 || (hostOptions.size() == 1 && !application.isOneHostCluster())) {
+            if (hostOptions.isEmpty() || (hostOptions.size() == 1 && !application.isOneHostCluster())) {
                 throw new ParseException("not enough hosts for cluster: " + clusterEntry.getKey());
             }
         }

--- a/src/main/java/lcmc/cluster/ui/wizard/CoroConfig.java
+++ b/src/main/java/lcmc/cluster/ui/wizard/CoroConfig.java
@@ -563,7 +563,7 @@ final class CoroConfig extends DialogCluster {
 
                 if (aisCastAddresses.size() < 2) {
                     final JLabel l;
-                    if (aisCastAddresses.size() < 1) {
+                    if (aisCastAddresses.isEmpty()) {
                         l = new JLabel(Tools.getString("Dialog.Cluster.CoroConfig.WarningAtLeastTwoInt"));
                     } else {
                         // TODO: we need to check if there is bond interface

--- a/src/main/java/lcmc/cluster/ui/wizard/HbConfig.java
+++ b/src/main/java/lcmc/cluster/ui/wizard/HbConfig.java
@@ -652,7 +652,7 @@ final class HbConfig extends DialogCluster {
                 configPanel.add(new JLabel(" "));
                 if (castAddresses.size() < 2) {
                     final JLabel l;
-                    if (castAddresses.size() < 1) {
+                    if (castAddresses.isEmpty()) {
                         l = new JLabel(Tools.getString("Dialog.Cluster.HbConfig.WarningAtLeastTwoInt"));
                     } else {
                         l = new JLabel(Tools.getString("Dialog.Cluster.HbConfig.WarningAtLeastTwoInt.OneMore"));

--- a/src/main/java/lcmc/crm/ui/CrmGraph.java
+++ b/src/main/java/lcmc/crm/ui/CrmGraph.java
@@ -920,7 +920,7 @@ public class CrmGraph extends ResourceGraph {
             return Tools.getDefaultColor("CRMGraph.FillPaintUnknown");
         } else if (vipl.contains(v) || Application.isTest(runMode)) {
             final List<Color> colors = si.getHostColors(runMode);
-            if (colors.size() >= 1) {
+            if (!colors.isEmpty()) {
                 return colors.get(0);
             } else {
                 return Color.WHITE; /* more colors */

--- a/src/main/java/lcmc/crm/ui/resource/CloneMenu.java
+++ b/src/main/java/lcmc/crm/ui/resource/CloneMenu.java
@@ -115,7 +115,7 @@ public class CloneMenu extends ServiceMenu {
                                         return false;
                                     }
                                     final List<String> runningOnNodes = cloneInfo.getRunningOnNodes(runMode);
-                                    if (runningOnNodes == null || runningOnNodes.size() < 1) {
+                                    if (runningOnNodes == null || runningOnNodes.isEmpty()) {
                                         return false;
                                     }
                                     boolean runningOnNode = false;

--- a/src/main/java/lcmc/crm/ui/resource/PcmkMultiSelectionMenu.java
+++ b/src/main/java/lcmc/crm/ui/resource/PcmkMultiSelectionMenu.java
@@ -950,7 +950,7 @@ public class PcmkMultiSelectionMenu {
                                             return false;
                                         }
                                         final List<String> runningOnNodes = si.getRunningOnNodes(Application.RunMode.LIVE);
-                                        if (runningOnNodes == null || runningOnNodes.size() < 1) {
+                                        if (runningOnNodes == null || runningOnNodes.isEmpty()) {
                                             return false;
                                         }
                                         boolean runningOnNode = false;

--- a/src/main/java/lcmc/crm/ui/resource/ServiceMenu.java
+++ b/src/main/java/lcmc/crm/ui/resource/ServiceMenu.java
@@ -655,7 +655,7 @@ public class ServiceMenu {
                                         return false;
                                     }
                                     final List<String> runningOnNodes = serviceInfo.getRunningOnNodes(runMode);
-                                    if (runningOnNodes == null || runningOnNodes.size() < 1) {
+                                    if (runningOnNodes == null || runningOnNodes.isEmpty()) {
                                         return false;
                                     }
                                     boolean runningOnNode = false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Faisal Hameed