### PR TITLE
Code quality fix - Public constants should be declared "static final" rather than merely "final".

### DIFF
--- a/src/main/java/lcmc/cluster/domain/Cluster.java
+++ b/src/main/java/lcmc/cluster/domain/Cluster.java
@@ -58,12 +58,12 @@ public class Cluster implements Comparable<Cluster> {
     private final Set<Host> hosts = new LinkedHashSet<Host>();
     private ClusterTab clusterTab = null;
     /** Default colors of the hosts. */
-    private final Color[] defaultHostColors = {new Color(228, 228, 32),
-                                               new Color(102, 204, 255), /* blue */
-                                               Color.PINK,
-                                               new Color(255, 100, 0), /* orange */
-                                               Color.WHITE,
-                                              };
+    private static final Color[] DEFAULT_HOST_COLORS = {new Color(228, 228, 32),
+                                                   new Color(102, 204, 255), /* blue */
+                                                   Color.PINK,
+                                                   new Color(255, 100, 0), /* orange */
+                                                   Color.WHITE,
+                                                  };
     private boolean savable = true;
     private boolean clusterTabClosable = true;
 
@@ -104,8 +104,8 @@ public class Cluster implements Comparable<Cluster> {
     public void addHost(final Host host) {
         final int id = hosts.size();
         host.setPositionInTheCluster(id);
-        if (id < defaultHostColors.length) {
-            host.setColor(defaultHostColors[id]);
+        if (id < DEFAULT_HOST_COLORS.length) {
+            host.setColor(DEFAULT_HOST_COLORS[id]);
         }
         hosts.add(host);
         proxyHosts.add(host);

--- a/src/main/java/lcmc/drbd/domain/NetInterface.java
+++ b/src/main/java/lcmc/drbd/domain/NetInterface.java
@@ -59,10 +59,10 @@ public final class NetInterface extends ResourceValue implements Value {
     private final String networkIp;
     private final boolean bridge;
     private final AddressFamily addressFamily;
-    private final String IPV6_STRING = "ipv6";
-    private final String IPV4_STRING = "ipv4";
-    private final String SSOCKS_STRING = "ssocks";
-    private final String SDP_STRING = "sdp";
+    private static final String IPV6_STRING = "ipv6";
+    private static final String IPV4_STRING = "ipv4";
+    private static final String SSOCKS_STRING = "ssocks";
+    private static final String SDP_STRING = "sdp";
 
     /**
      * @param line


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1170 - Public constants should be declared "static final" rather than merely "final". 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1170
 
Please let me know if you have any questions.

Faisal Hameed