### PR TITLE
Code quality fix -  Parsing should be used to convert "Strings" to primitives.

### DIFF
--- a/src/main/java/lcmc/common/ui/Logs.java
+++ b/src/main/java/lcmc/common/ui/Logs.java
@@ -224,17 +224,17 @@ public class Logs extends ConfigDialog {
                                 final int month1 = monthsHash.get(m1.group(1));
                                 final int month2 = monthsHash.get(m2.group(1));
 
-                                final int day1 = Integer.valueOf(m1.group(2));
-                                final int day2 = Integer.valueOf(m2.group(2));
+                                final int day1 = Integer.parseInt(m1.group(2));
+                                final int day2 = Integer.parseInt(m2.group(2));
 
-                                final int hour1 = Integer.valueOf(m1.group(3));
-                                final int hour2 = Integer.valueOf(m2.group(3));
+                                final int hour1 = Integer.parseInt(m1.group(3));
+                                final int hour2 = Integer.parseInt(m2.group(3));
 
-                                final int min1 = Integer.valueOf(m1.group(4));
-                                final int min2 = Integer.valueOf(m2.group(4));
+                                final int min1 = Integer.parseInt(m1.group(4));
+                                final int min2 = Integer.parseInt(m2.group(4));
 
-                                final int sec1 = Integer.valueOf(m1.group(5));
-                                final int sec2 = Integer.valueOf(m2.group(5));
+                                final int sec1 = Integer.parseInt(m1.group(5));
+                                final int sec2 = Integer.parseInt(m2.group(5));
 
                                 if (month1 != month2) {
                                     return month1 < month2 ? -1 : 1;

--- a/src/main/java/lcmc/host/domain/HostParser.java
+++ b/src/main/java/lcmc/host/domain/HostParser.java
@@ -450,7 +450,7 @@ public class HostParser {
             }
         }
         if (id != null && x != null && y != null) {
-            servicePositions.put(id, new Point2D.Double(new Double(x).doubleValue(), new Double(y).doubleValue()));
+            servicePositions.put(id, new Point2D.Double(Double.parseDouble(x), Double.parseDouble(y)));
         }
     }
     /** Parses the gui options info. */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2130 - Parsing should be used to convert "Strings" to primitives.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2130

Please let me know if you have any questions.

Faisal Hameed